### PR TITLE
AT-40 | Fix Tests\Feature\Auth\RegistrationTest > new users can register

### DIFF
--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -6,7 +6,10 @@ test('registration screen can be rendered', function () {
     $response->assertStatus(200);
 });
 
-test('new users can register', function () {
+test('new users can register if they are in the list of app override emails', function () {
+
+    config(['app.override_emails' => ['test@example.com']]);
+
     $response = $this->post('/register', [
         'name' => 'Test User',
         'email' => 'test@example.com',

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -20,3 +20,17 @@ test('new users can register if they are in the list of app override emails', fu
     $this->assertAuthenticated();
     $response->assertRedirect(route('dashboard', absolute: false));
 });
+
+test('new users cannot register if they are not in the list of app override emails', function () {
+
+    config(['app.override_emails' => []]);
+
+    $response = $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $response->assertRedirect(route('home', absolute: false));
+});


### PR DESCRIPTION
After we introduced the config app override emails, the test was failing. This updates this test to check whether a user can register if they are in the list of app override emails

[AT-40]